### PR TITLE
ci: ship Koaia, not "My Custom App", and unbreak the custom build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,37 +61,3 @@ jobs:
           name: koaia-${{ matrix.artifact-name }}
           path: packages/
           retention-days: 30
-
-  release:
-    name: Create Release
-    needs: build
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
-
-    steps:
-      - name: Download all artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: all-packages
-          pattern: koaia-*
-          merge-multiple: true
-
-      - name: Create Release (on tags)
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v2
-        with:
-          files: all-packages/*
-          draft: false
-          prerelease: false
-          generate_release_notes: true
-
-      - name: Upload to Continuous Release (on main/master)
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
-        uses: softprops/action-gh-release@v2
-        with:
-          name: "Continuous Build"
-          tag_name: "continuous"
-          files: all-packages/*
-          draft: false
-          prerelease: true
-          generate_release_notes: false

--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -20,24 +20,38 @@ jobs:
           - os: ubuntu-latest
             platform: linux-x86_64
             artifact-name: linux-x86_64
+          - os: ubuntu-24.04-arm
+            platform: linux-aarch64
+            artifact-name: linux-aarch64
           - os: macos-latest
             platform: macos-arm
             artifact-name: macos-arm
+          - os: macos-latest
+            platform: macos-intel
+            artifact-name: macos-intel
+            target-arch: x86_64
           - os: windows-latest
             platform: windows
             artifact-name: windows
+          - os: ubuntu-24.04
+            platform: wasm
+            artifact-name: wasm
+            target-platform: wasm
+            artifact-path: packages/*.zip
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: ossia score build
         id: score
         uses: ossia/actions/custom-score-build@master
         with:
+          target-arch: ${{ matrix.target-arch || '' }}
+          target-platform: ${{ matrix.target-platform || '' }}
           cmake-options: >
             -DSCORE_ENABLE_ADDONS=score-addon-librediffusion
-            -DSCORE_DISABLE_PLUGINS=score-plugin-faust,score-plugin-jit,score-plugin-vst,score-plugin-vst3,score-plugin-clap,score-plugin-lv2,score-plugin-avnd,score-plugin-pd,score-plugin-ysfx,score-plugin-controlsurface,score-plugin-spline3d,score-plugin-recording,score-plugin-nodal,score-plugin-spline,score-plugin-mapping,score-plugin-threedim
+            -DSCORE_DISABLE_PLUGINS=score-plugin-faust,score-plugin-jit,score-plugin-vst,score-plugin-vst3,score-plugin-clap,score-plugin-lv2,score-plugin-pd,score-plugin-ysfx,score-plugin-controlsurface,score-plugin-spline3d,score-plugin-recording,score-plugin-nodal,score-plugin-spline,score-plugin-mapping,score-plugin-threedim
             -DSCORE_QT_PLUGINS_NO_QTQUICK3D=1
           macos-certificate-base64: ${{ secrets.MAC_CERT_B64 }}
           macos-certificate-password: ${{ secrets.MAC_CERT_PASSWORD }}
@@ -48,7 +62,7 @@ jobs:
       - name: Package custom ossia score app
         uses: ossia/actions/package-custom-app@master
         with:
-          app-name: "My Custom App"
+          app-name: "Koaia"
           qml-files: "qml"
           # Optional: Add your score file here
           score-file: "score/app.score"
@@ -76,7 +90,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: custom-app-${{ matrix.artifact-name }}
-          path: packages/
+          path: ${{ matrix.artifact-path || 'packages/' }}
           retention-days: 30
 
   release:

--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -33,6 +33,9 @@ jobs:
           - os: windows-latest
             platform: windows
             artifact-name: windows
+          - os: windows-11-arm
+            platform: windows-arm64
+            artifact-name: windows-arm64
           - os: ubuntu-24.04
             platform: wasm
             artifact-name: wasm


### PR DESCRIPTION
`full-build.yml` builds the app users are actually meant to get — the one with `score-addon-librediffusion`. Three things were wrong with it.

## 1. It shipped "My Custom App"

The template's `app-name` was never changed, so it published `My.Custom.App-linux-x86_64.AppImage` and friends. Those assets are **still on the continuous release**, dated March:

```
My.Custom.App-windows.zip            2026-03-13
My.Custom.App-linux-x86_64.AppImage  2026-03-13
My.Custom.App-macos-arm.dmg          2026-03-13
Koaia-linux-x86_64.AppImage          2026-07-11   <- from build.yml, stock score
```

## 2. linux and windows have been failing since March

The workflow disables `score-plugin-avnd` while enabling `score-addon-librediffusion`, which is an avendish addon:

```
FAILED: .../score_addon_librediffusion.dir/Unity/unity_0_cxx.cxx.o
/build/streamdiffusion_avnd.cpp:23:10: fatal error: 'Avnd/Factories.hpp' file not found
```

`Avnd/Factories.hpp` is `src/plugins/score-plugin-avnd/Avnd/Factories.hpp`, so the addon cannot build with that plugin disabled. Removed it from the disable list. (macOS happened to survive; linux and windows did not.)

## 3. Two workflows published to the same tag

`build.yml` packages a *stock* score for quick feedback, and it was also publishing to `continuous`. Since full-build has been broken since March, **what users have downloaded since then is Koaia without librediffusion** — sitting next to the stale March assets from the real build.

`build.yml` now uploads artifacts only; releasing belongs to `full-build.yml`. If the real build fails, there is no release, which is the honest outcome.

## Platform coverage

Added `macos-intel` (cross-compiled via `target-arch: x86_64`, since `macos-latest` is ARM), `linux-aarch64` (`ubuntu-24.04-arm`, free for public repos), and `wasm`.

> [!IMPORTANT]
> The wasm job needs ossia/actions#24 and ossia/score#2155 merged first. Until then it will fail — deliberately, rather than quietly producing a bundle without librediffusion in it.

## Still to do (not in this PR)

The four stale `My.Custom.App-*` assets need deleting from the continuous release; that is a destructive change to a public release, so I left it for you. Say the word and I'll remove them.

## Validation

The `macos-intel` / `linux-aarch64` / wasm pattern is already proven: sat-mtl/livepose#71 runs the same matrix and its `linux-aarch64` and `wasm` jobs are green. Here, the custom-score jobs are what this PR's own run exercises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VxtUwsfk4JN46WropbwfqC
